### PR TITLE
feat(eslint-config-arcadia): enable sort-prop-types

### DIFF
--- a/packages/eslint-config-arcadia-base/.eslintrc.js
+++ b/packages/eslint-config-arcadia-base/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // root already extends arcadia-base
+  rules: {
+    // match upstream because dangling comma conflicts are _the worst_
+    'comma-dangle': 'off',
+    // far too many disagreements to be useful
+    'prettier/prettier': 'off',
+  },
+};

--- a/packages/eslint-config-arcadia-base/.eslintrc.yaml
+++ b/packages/eslint-config-arcadia-base/.eslintrc.yaml
@@ -1,7 +1,0 @@
----
-  # root already extends arcadia-base
-  rules:
-    # match upstream because dangling comma conflicts are _the worst_
-    comma-dangle: off
-    # far too many disagreements to be useful
-    prettier/prettier: off

--- a/packages/eslint-config-arcadia/rules/react.js
+++ b/packages/eslint-config-arcadia/rules/react.js
@@ -126,7 +126,7 @@ module.exports = {
 
     // Enforce propTypes declarations alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md
-    'react/sort-prop-types': ['off', {
+    'react/sort-prop-types': ['error', {
       ignoreCase: true,
       callbacksLast: false,
       requiredFirst: false,
@@ -138,7 +138,7 @@ module.exports = {
 
     // Enforce props alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
-    'react/jsx-sort-props': ['off', {
+    'react/jsx-sort-props': ['error', {
       ignoreCase: true,
       callbacksLast: false,
       shorthandFirst: false,


### PR DESCRIPTION
This enables the following linters by default:

- `sort-prop-types`
- `jsx-sort-props`